### PR TITLE
Typecast port (int) to string in url->dsn conversion

### DIFF
--- a/postgres/__init__.py
+++ b/postgres/__init__.py
@@ -214,7 +214,7 @@ def url_to_dsn(url):
     if host is not None:
         dsn += " host=" + host
     if port is not None:
-        dsn += " port=" + port
+        dsn += " port=" + str(port)
 
     return dsn
 


### PR DESCRIPTION
Ran into this when working on Masspay over at https://github.com/gratipay/gratipay.com/pull/3356.

Here's a traceback:
```
  File "/xxx/gratipay/gratipay.com/gratipay/main.py", line 64, in <module>
    website.db = gratipay.wireup.db(env)
  File "/xxx/gratipay/gratipay.com/gratipay/wireup.py", line 54, in db
    db = GratipayDB(dburl, maxconn=maxconn)
  File "/xxx/gratipay/gratipay.com/env/lib/python2.7/site-packages/postgres/__init__.py", line 323, in __init__
    dsn = url_to_dsn(url)
  File "/xxx/gratipay/gratipay.com/env/lib/python2.7/site-packages/postgres/__init__.py", line 217, in url_to_dsn
    dsn += " port=" + port
TypeError: coercing to Unicode: need string or buffer, int found
```
